### PR TITLE
fix: text renamed

### DIFF
--- a/components/navigation/side-navigation/index.tsx
+++ b/components/navigation/side-navigation/index.tsx
@@ -70,7 +70,10 @@ export const items = [
         href: "/apis/businesses/preferred-partners",
         children: "Preferred Partners",
       },
-      { href: "/apis/businesses/partoo", children: "Partoo" },
+      {
+        href: "/apis/businesses/review-management-tool",
+        children: "Review Management Tool",
+      },
       { href: "/apis/businesses/payments", children: "Payments" },
       { href: "/apis/businesses/permitted-list", children: "Permitted List" },
       { href: "/apis/businesses/privatisations", children: "Privatisations" },
@@ -288,7 +291,10 @@ export const items = [
       { href: "/apis/users/user", children: "Users" },
       { href: "/apis/users/current-user", children: "Current User" },
       { href: "/apis/users/detectives", children: "Detectives" },
-      { href: "/apis/users/partoo", children: "Partoo" },
+      {
+        href: "/apis/users/review-management-tool",
+        children: "Review Management Tool",
+      },
     ],
   },
   {

--- a/pages/apis/businesses/review-management-tool/index.md
+++ b/pages/apis/businesses/review-management-tool/index.md
@@ -1,5 +1,5 @@
 ---
-title: Partoo Business intergrations
+title: Business intergrations
 ---
 {% section %}
 {% layoutTwoCol %}
@@ -7,13 +7,13 @@ title: Partoo Business intergrations
 {% methodCopy %}
 {% methodInfo %}
   # {% $markdoc.frontmatter.title %}
-  Connect given business to Partoo.
+  Connect given business to Review Management Tool.
 
   If any erros occur you can access the [errors guide](/errors).
 {% /methodInfo %}
 {% list title="Parameters" %}
   {% listitem title="id" validation="path integer" type="Required" %}
-  Connect specific business to Partoo with provided business `id`.
+  Connect specific business to Review Management Tool with provided business `id`.
   {% /listitem %}
 {% /list %}
 {% /methodCopy %}
@@ -69,12 +69,12 @@ title: Partoo Business intergrations
 
 {% methodCopy %}
 {% methodInfo %}
-  # Update Business on Partoo
-  Update given business on Partoo.
+  # Update Business
+  Update given business on Review Management Tool.
 {% /methodInfo %}
 {% list title="Parameters" %}
   {% listitem title="id" validation="path integer" type="Required" %}
-  Update specific business to Partoo with provided business `id`.
+  Update specific business to Review Management Tool with provided business `id`.
   {% /listitem %}
 {% /list %}
 {% /methodCopy %}
@@ -132,12 +132,12 @@ title: Partoo Business intergrations
 
 {% methodCopy %}
 {% methodInfo %}
-  # Disconnect Business on Partoo
-  Disconnect the business from Partoo.
+  # Disconnect Business
+  Disconnect the business from Review Management Tool.
 {% /methodInfo %}
 {% list title="Parameters" %}
   {% listitem title="id" validation="path integer" type="Required" %}
-  Disconnect specific business from Partoo with provided business `id`.
+  Disconnect specific business from Review Management Tool with provided business `id`.
   {% /listitem %}
 {% /list %}
 {% /methodCopy %}

--- a/pages/apis/users/review-management-tool/index.md
+++ b/pages/apis/users/review-management-tool/index.md
@@ -1,5 +1,5 @@
 ---
-title: Partoo User intergrations
+title: User intergrations
 ---
 {% section %}
 {% layoutTwoCol %}
@@ -7,13 +7,13 @@ title: Partoo User intergrations
 {% methodCopy %}
 {% methodInfo %}
   # {% $markdoc.frontmatter.title %}
-  Connect User to Partoo.
+  Connect User to Review Management Tool.
 
   If any erros occur you can access the [errors guide](/errors).
 {% /methodInfo %}
 {% list title="Parameters" %}
   {% listitem title="id" validation="path integer" type="Required" %}
-  Connect specific User to Partoo with provided User `id`.
+  Connect specific User to Review Management Tool with provided User `id`.
   {% /listitem %}
 {% /list %}
 {% /methodCopy %}
@@ -69,12 +69,12 @@ title: Partoo User intergrations
 
 {% methodCopy %}
 {% methodInfo %}
-  # Disconnect User on Partoo
-  Disconnect the User from Partoo.
+  # Disconnect User
+  Disconnect the User from Review Management Tool.
 {% /methodInfo %}
 {% list title="Parameters" %}
   {% listitem title="id" validation="path integer" type="Required" %}
-  Disconnect specific User from Partoo with provided User `id`.
+  Disconnect specific User from Review Management Tool with provided User `id`.
   {% /listitem %}
 {% /list %}
 {% /methodCopy %}
@@ -127,8 +127,8 @@ title: Partoo User intergrations
 
 {% methodCopy %}
 {% methodInfo %}
-  # Partoo Business reviews
-  Search for the reviews of your businesses on Partoo.
+  # Business reviews
+  Search for the reviews of your businesses on Review Management Tool.
 {% /methodInfo %}
 {% list title="Parameters" %}
   {% listitem title="partoo_business_ids" validation="String[]" type="Required" %}


### PR DESCRIPTION
Renamed `Partoo` too `Review Management Tool`. The endpoints still have Partoo in them until the Backend changes them.